### PR TITLE
only process js files

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,11 +95,18 @@ exports.processFile = function (source, dest, exclude, option) {
   }
 
   if (flag === 'file') { // process file
-    content = fs.readFileSync(source).toString();
-    content = content.toString();
-    content = this.process(source, content);
     mkdirSync(path.dirname(dest));
-    fs.writeFileSync(dest, content);
+    var extname = path.extname(source);
+    if (extname && extname !== '.js') {
+      // if it is not a js file, copy it
+      content = fs.readFileSync(source);
+      fs.writeFileSync(dest, content);
+    } else {
+      content = fs.readFileSync(source).toString();
+      content = content.toString();
+      content = this.process(source, content);
+      fs.writeFileSync(dest, content);
+    }
   } else { // process dir
     var nodes = fs.readdirSync(source);
     var tmpPath, tmpDest;


### PR DESCRIPTION
The source directory may contain other filetype files, for example css. We should only process the js content.
