### PR TITLE
Easier integration with Coveralls with LCOV output

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,12 +161,13 @@ exports.require = function (mo, file) {
 /**
  * sum the coverage rate
  */
-exports.coverage = function () {
+exports.coverageStats = function () {
   var file;
   var tmp;
   var total;
   var touched;
   var n, len;
+  var stats = {};
   if (typeof _$jscoverage === 'undefined') {
     return;
   }
@@ -182,12 +183,20 @@ exports.coverage = function () {
           touched ++;
       }
     }
-    console.log(
-      "[JSCOVERAGE] " +
-      file + ":" +
-      (total ? (((touched / total) * 100).toFixed(2) + '%') : "Not prepared!!!")
-    );
+    stats[file] = {
+        total: total,
+        touched: touched,
+        percent: total ? ((touched / total) * 100).toFixed(2) + '%' : "Not prepared!!!"
+    };
   }
+  return stats;
+};
+
+exports.coverage = function () {
+    var stats = exports.coverageStats();
+    Object.keys(stats).forEach(function (file) {
+        console.log("[JSCOVERAGE] " + file + ":" + stats[file].percent);
+    });
 };
 
 exports.coverageDetail = function () {
@@ -223,6 +232,33 @@ exports.coverageDetail = function () {
     }
   }
 };
+
+exports.getLCOV = function () {
+  var tmp;
+  var total;
+  var touched;
+  var n, len;
+  var lcov = "";
+  if (typeof _$jscoverage === 'undefined') {
+    return;
+  }
+  Object.keys(_$jscoverage).forEach(function (file) {
+    lcov += "SF:" + file + "\n";
+    tmp = _$jscoverage[file];
+    if (typeof tmp === 'function' || tmp.length === undefined) return;
+    total = touched = 0;
+    for (n = 0, len = tmp.length; n < len; n++) {
+      if (tmp[n] !== undefined) {
+        lcov += "DA:" + n + "," + tmp[n] + "\n";
+        total ++; 
+        if (tmp[n] > 0) touched++; 
+      }
+    }
+    lcov += "end_of_record\n";
+  });
+  return lcov;
+};
+
 
 function processLinesMask(lines) {
   function processLeft3(arr, offset) {


### PR DESCRIPTION
Hello,

I've been using jscoverage pretty extensively (since it was still a C++-based project run by a different maintainer), and recently I've started using it in conjunction with [coveralls.io](https://coveralls.io/) a code coverage tracking service, and the [node-coveralls](https://github.com/cainus/node-coveralls) interfacing lib.

To do this, I've [copy-pasted and modified the `coverageDetail` function](https://github.com/uber/redis-broadcast/blob/194baad902900a23f500f52b8fa4c5ace1fbbd3c/test/test.js#L151), which works, but is a bit ugly, so this morning I decided to create special exporter functions for the coverage summary and coverage detail functions (this PR), [which makes my jscoverage test function that integrates with coveralls _much_ easier to read](https://github.com/uber/redis-broadcast/blob/master/test/test.js#L151), as you can see.

LCOV is a standard mechanism for listing code coverage, and can integrate not only with coveralls, but [gcov](http://gcc.gnu.org/onlinedocs/gcc/Gcov.html), [Hudson/Jenkins, through a converter](https://github.com/eriwen/lcov-to-cobertura-xml), and so on.

Similarly, I added a simple JSON object format for the coverage summary so once I get a library to 100% code coverage, dropping below 100% becomes a test failure.

I hope you find all this as useful as I have, and thank you for this great library. :)
