### PR TITLE
Fixed generated path for Windows users

### DIFF
--- a/lib/jscoverage.js
+++ b/lib/jscoverage.js
@@ -42,7 +42,7 @@ function jscFunctionBody() {
 function genCodeCoverage(instrObj) {
   if (!instrObj) return '';
   var code = [];
-  var filename = instrObj.file;
+  var filename = instrObj.file.replace(/\\/g, "\\\\");
   var lines = instrObj.lines;
   var conditions = instrObj.conditions;
   var src = instrObj.src;


### PR DESCRIPTION
Without this, it would be impossible to Windows users succesfully use jscoverage.
Fixes #8 
