### PR TITLE
Loading a file more than once clobbers coverage.

### DIFF
--- a/lib/jscoverage.js
+++ b/lib/jscoverage.js
@@ -48,7 +48,6 @@ function jscFunctionBody() {
       var storage;
       switch (type) {
         case 'init':
-
           if(cov[file]){
             storage = cov[file];
           } else {
@@ -56,11 +55,11 @@ function jscFunctionBody() {
             for (var i = 0; i < line.length; i ++) {
               storage[line[i]] = 0;
             }
+            var condition = express;
+            var source = start;
+            storage.condition = condition;
+            storage.source = source;
           }
-          var condition = express;
-          var source = start;
-          storage.condition = condition;
-          storage.source = source;
           cov[file] = storage;
           break;
         case 'line':

--- a/lib/jscoverage.js
+++ b/lib/jscoverage.js
@@ -48,9 +48,14 @@ function jscFunctionBody() {
       var storage;
       switch (type) {
         case 'init':
-          storage = [];
-          for (var i = 0; i < line.length; i ++) {
-            storage[line[i]] = 0;
+
+          if(cov[file]){
+            storage = cov[file];
+          } else {
+            storage = [];
+            for (var i = 0; i < line.length; i ++) {
+              storage[line[i]] = 0;
+            }
           }
           var condition = express;
           var source = start;

--- a/test/jscoverage.js
+++ b/test/jscoverage.js
@@ -15,7 +15,11 @@ func.pop();
 
 var wrapperGlobal = eval('(function(){ var global = {}; var $lines$ = [1]; var $conds$ = {"1_1_1": 0}; var $source$=["var a = a ? 1: 0;"];' + func.join('\n') + ' return global;})');
 
-var _global = wrapperGlobal();
+var _global;
+
+beforeEach(function(){
+  _global = wrapperGlobal();
+});
 
 describe('lib/jscoverage.js', function(){
   it('jscFunctionBody shoud be ok', function(){
@@ -39,5 +43,18 @@ describe('lib/jscoverage.js', function(){
       err = e;
     }
     expect(err.message).to.match(/filename needed!/);
+  });
+  it('should carry over existing coverage through inits', function(){
+    // Init once
+    _global._$jscmd('$file$', 'init', [1], [], []);
+    // mark line
+    _global._$jscmd('$file$', 'line', 1);
+
+    // Init twice
+    _global._$jscmd('$file$', 'init', [1], [], []);
+    // mark line again
+    _global._$jscmd('$file$', 'line', 1);
+
+    expect(_global._$jscoverage['$file$'][1]).to.be(2);
   });
 });

--- a/test/jscoverage.js
+++ b/test/jscoverage.js
@@ -46,15 +46,17 @@ describe('lib/jscoverage.js', function(){
   });
   it('should carry over existing coverage through inits', function(){
     // Init once
-    _global._$jscmd('$file$', 'init', [1], [], []);
+    _global._$jscmd('$file2$', 'init', [1], ['1_1_1'], ['source']);
     // mark line
-    _global._$jscmd('$file$', 'line', 1);
+    _global._$jscmd('$file2$', 'line', 1);
 
     // Init twice
-    _global._$jscmd('$file$', 'init', [1], [], []);
+    _global._$jscmd('$file2$', 'init', [1], [], []);
     // mark line again
-    _global._$jscmd('$file$', 'line', 1);
+    _global._$jscmd('$file2$', 'line', 1);
 
-    expect(_global._$jscoverage['$file$'][1]).to.be(2);
+    expect(_global._$jscoverage['$file2$'][1]).to.be(2);
+    expect(_global._$jscoverage['$file2$']['condition'].length).to.be(1);
+    expect(_global._$jscoverage['$file2$']['source'].length).to.be(1);
   });
 });


### PR DESCRIPTION
I ran into a situation where I was loading a source file in a `beforeEach`. This meant I only got coverage for the last test since `init` was triggered on each test.

I was able to move the load to a `before` hook and have it work with the existing library, but it seems like if there is previously existing coverage that it should be additive to that.
