### PR TITLE
[Bug] jscoverage output files name is incorrect when use cli to convert ...

### DIFF
--- a/bin/jscoverage
+++ b/bin/jscoverage
@@ -55,7 +55,7 @@ try {
         });
       }
       count ++;
-      var destFile = path.join(dest, file.substr(source.length));
+      var destFile = path.join(dest, file.split(path.sep).pop());
       if (flag) {
         // copy exclude file
         fs.save(destFile, fs.readFileSync(file));


### PR DESCRIPTION
...from a souredir to destdir (in windows)

Example case:
I have a source dir:

```
──source
   ├─test.a.js
   ├─test.b.js
   └─test.c.js
```

then I use cli to convert  `/source` files to `/dest`

``` js
jscoverage ./source ./dest/source
```

then I get dest files

```
──source
   ├─est.a.js
   ├─est.b.js
   └─est.c.js
```

Each filename in `dest` miss a char. Because you use `file.substr(source.length)` to get the file name,
but source is `./source` and file is `source/test.x.js`, so then sub length is wrong.

I use `file.split(path.sep).pop()` to get filename to fix   
