### PR TITLE
minimum coffee-script version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "xfs" : "0.1.8",
     "ejs": "1.0.0",
     "debug": "1.0.3",
-    "coffee-script": "*"
+    "coffee-script": ">=1.7.0"
   },
   "devDependencies" : {
     "mocha" : "*",


### PR DESCRIPTION
From http://coffeescript.org/

"1.7.0 — JANUARY 28, 2014
When requiring CoffeeScript files in Node you must now explicitly register the compiler. This can be done with require 'coffee-script/register' or CoffeeScript.register(). Also for configuration such as Mocha's, use coffee-script/register."

