### PR TITLE
resolve uglify-js CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,20 +10,20 @@
     "test": "./node_modules/mocha/bin/_mocha -t 60000 -r ./index.js -R spec --covinject true test/"
   },
   "engines": {
-    "node" : ">=0.8"
+    "node": ">=0.8"
   },
-  "dependencies" : {
-    "uglify-js" : "2.4.15",
-    "optimist" : "0.3.1",
-    "xfs" : "0.1.8",
+  "dependencies": {
+    "uglify-js": "~2.8.26",
+    "optimist": "0.3.1",
+    "xfs": "0.1.8",
     "ejs": "1.0.0",
     "debug": "1.0.3",
     "coffee-script": "*"
   },
-  "devDependencies" : {
-    "mocha" : "*",
-    "expect.js" : "*",
-    "xfs" : "*"
+  "devDependencies": {
+    "mocha": "*",
+    "expect.js": "*",
+    "xfs": "*"
   },
   "repository": {
     "type": "git",
@@ -38,8 +38,11 @@
     "tool"
   ],
   "author": "fish <zhengxinlin@gmail.com>, kate.sf <kate.sf@taobao.com>",
-  "contributors":[
-    { "name": "christineRR", "email": "rongkunli1215@gmail.com" }
+  "contributors": [
+    {
+      "name": "christineRR",
+      "email": "rongkunli1215@gmail.com"
+    }
   ],
   "license": "MIT"
 }


### PR DESCRIPTION
Update uglify-js, while keeping `npm test1` passing, in order to resolve vulnerability reports associated with earlier editions of uglify-js.