### PR TITLE
Fix copying excluded files

### DIFF
--- a/bin/jscoverage
+++ b/bin/jscoverage
@@ -58,7 +58,7 @@ try {
       var destFile = path.join(dest, file.substr(source.length));
       if (flag) {
         // copy exclude file
-        fs.save(destFile, fs.readFileSync(file));
+        fs.writeFileSync(destFile, fs.readFileSync(file));
       } else {
         jscoverage.processFile(file, destFile);
       }


### PR DESCRIPTION
`xfs.save()` is an alias for `xfs.writeFile()` (async) but a callback method isn't provided. Explicitly calling writeFileSync instead prevents attempting to invoke an undefined callback.

In order to get the synchronous save method, we need to load the sync method from `xfs.sync()`.