### PR TITLE
Use modern versions of node_js runtime on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
-  - "0.8"
+  - node
+  - lts/*

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -53,8 +53,7 @@ describe("index.js", function () {
         serv.close(done);
       });
     });
-    /*
-    it('should return an jsc convert dir', function (done) {
+    xit('should return an jsc convert dir', function (done) {
       var source = path.join(__dirname, './dir');
       var dest = path.join(__dirname, './dir-cov');
       index.processFile(source, dest);
@@ -65,7 +64,7 @@ describe("index.js", function () {
         done();
       });
     });
-    it('should ignore exclude', function (done) {
+    xit('should ignore exclude', function (done) {
       var source = path.join(__dirname, './dir');
       var dest = path.join(__dirname, './dir-cov');
       index.processFile(source, dest, ['a2', /\.md$/i]);
@@ -74,13 +73,10 @@ describe("index.js", function () {
         done();
       });
     });
-    */
-    it('should throw error when source and dest not currect', function () {
-      try {
+    it('should throw error when source and dest not correct', function () {
+      expect(function() {
         index.processFile();
-      } catch (e) {
-        expect(e.message).to.match(/path must be a string/);
-      }
+      }).to.throwException(TypeError);
     });
     it('should throw error when source and dest not currect', function () {
       function _empty() {


### PR DESCRIPTION
Use of modern language features is breaking the ancient Node.js runtimes on CI, but it can be fixed.